### PR TITLE
Ferigis.23.ignore swagger trails

### DIFF
--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -87,7 +87,7 @@ validate_metadata(Metadata) ->
   validate_swagger_map(Metadata).
 
 %% @hidden
--spec filter_cowboy_swagger_handler(trails:trail()) -> trails:trail().
+-spec filter_cowboy_swagger_handler([trails:trail()]) -> [trails:trail()].
 filter_cowboy_swagger_handler(Trails) ->
   F = fun(Trail) ->
     case trails:handler(Trail) of

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -7,6 +7,7 @@
 %% Utilities
 -export([enc_json/1, dec_json/1]).
 -export([swagger_paths/1, validate_metadata/1]).
+-export([filter_cowboy_swagger_handler/1]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Types.
@@ -53,7 +54,8 @@ to_json(Trails) ->
   Default = #{swagger => <<"2.0">>, info => #{title => <<"API-DOCS">>}},
   GlobalSpec = normalize_map_values(
     application:get_env(cowboy_swagger, global_spec, Default)),
-  SwaggerSpec = GlobalSpec#{paths => swagger_paths(Trails)},
+  SanitizeTrails = filter_cowboy_swagger_handler(Trails),
+  SwaggerSpec = GlobalSpec#{paths => swagger_paths(SanitizeTrails)},
   enc_json(SwaggerSpec).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -83,6 +85,18 @@ swagger_paths(Trails) ->
 -spec validate_metadata(trails:metadata()) -> trails:metadata().
 validate_metadata(Metadata) ->
   validate_swagger_map(Metadata).
+
+%% @hidden
+-spec filter_cowboy_swagger_handler(trails:trail()) -> trails:trail().
+filter_cowboy_swagger_handler(Trails) ->
+  F = fun(Trail) ->
+    case trails:handler(Trail) of
+      cowboy_swagger_handler  -> false;
+      cowboy_static           -> false;
+      _                       -> true
+    end
+  end,
+  lists:filter(F, Trails).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Private API.

--- a/test/cowboy_swagger_SUITE.erl
+++ b/test/cowboy_swagger_SUITE.erl
@@ -27,6 +27,7 @@ all() ->
 to_json_test(_Config) ->
   Trails = test_trails(),
   SwaggerJson = cowboy_swagger:to_json(Trails),
+  Result = jiffy:decode(SwaggerJson, [return_maps]),
   #{<<"paths">> :=
     #{<<"/a/{b}/{c}">> :=
       #{<<"delete">> :=
@@ -109,7 +110,9 @@ to_json_test(_Config) ->
         }
       }
     }
-  } = jiffy:decode(SwaggerJson, [return_maps]),
+  } = Result,
+  #{<<"paths">> := Paths} = Result,
+  2 = maps:size(Paths),
   {comment, ""}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -158,4 +161,6 @@ test_trails() ->
                }
      },
   [trails:trail("/a/[:b/[:c/[:d]]]", handler1, [], Metadata),
-   trails:trail("/a/:b/[:c]", handler2, [], Metadata)].
+    trails:trail("/a/:b/[:c]", handler2, [], Metadata),
+    trails:trail("/api-docs", cowboy_swagger_handler, [], Metadata),
+    trails:trail("/[...]", cowboy_swagger_handler, [], Metadata)].

--- a/test/cowboy_swagger_handler_SUITE.erl
+++ b/test/cowboy_swagger_handler_SUITE.erl
@@ -43,8 +43,9 @@ handler_test(_Config) ->
   Trails = trails:trails([example_echo_handler,
                           example_description_handler,
                           cowboy_swagger_handler]),
+  SanitizeTrails = cowboy_swagger:filter_cowboy_swagger_handler(Trails),
   ExpectedPaths = cowboy_swagger:dec_json(
-    cowboy_swagger:enc_json(cowboy_swagger:swagger_paths(Trails))),
+    cowboy_swagger:enc_json(cowboy_swagger:swagger_paths(SanitizeTrails))),
 
   %% GET swagger.json spec
   ct:comment("GET /api-docs/swagger.json should return 200 OK"),


### PR DESCRIPTION
The idea is filtering the trails inside the to_json function before getting the Swagger specifications.
In order to achieve this I have created a method called filter_cowboy_swagger_handler which is responsible of filtering the trails out if the handler is cowboy_static or cowboy_swagger_handler.