### PR TITLE
Handles the property parameter  as json list when it's empty

### DIFF
--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -123,7 +123,9 @@ normalize_path(Path) ->
 normalize_map_values(Map) when is_map(Map) ->
   normalize_map_values(maps:to_list(Map));
 normalize_map_values(Proplist) ->
-  F = fun({K, V}, Acc) when is_list(V) ->
+  F = fun({K, []}, Acc) ->
+        maps:put(K, normalize_list_values([]), Acc);
+      ({K, V}, Acc) when is_list(V) ->
         case io_lib:printable_list(V) of
           true  -> maps:put(K, list_to_binary(V), Acc);
           false -> maps:put(K, normalize_list_values(V), Acc)

--- a/test/cowboy_swagger_SUITE.erl
+++ b/test/cowboy_swagger_SUITE.erl
@@ -108,11 +108,16 @@ to_json_test(_Config) ->
           ],
           <<"responses">> := #{<<"200">> := #{<<"description">> := <<"bla">>}}
         }
-      }
+      },
+    <<"/a">> :=
+    #{<<"get">> := #{<<"description">> := <<"bla bla bla">>,
+      <<"parameters">> := [],
+      <<"produces">> := [<<"application/json">>],
+      <<"responses">> := #{<<"200">> := #{<<"description">> := <<"bla">>}}}}
     }
   } = Result,
   #{<<"paths">> := Paths} = Result,
-  2 = maps:size(Paths),
+  3 = maps:size(Paths),
   {comment, ""}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -160,6 +165,14 @@ test_trails() ->
                 responses => #{<<"200">> => #{description => "bla"}}
                }
      },
+  Metadata1 =
+    #{
+      get => #{description => <<"bla bla bla">>,
+        produces => ["application/json"],
+        responses => #{<<"200">> => #{description => "bla"}}
+      }
+    },
   [trails:trail("/a/[:b/[:c/[:d]]]", handler1, [], Metadata),
-   trails:trail("/a/:b/[:c]", handler2, [], Metadata) |
+   trails:trail("/a/:b/[:c]", handler2, [], Metadata),
+   trails:trail("/a", handler3, [], Metadata1)|
    cowboy_swagger_handler:trails()].


### PR DESCRIPTION
When we have a spec like this:

    #{get =>
      #{tags => ["vendors"],
        description => "Gets all Vendors from the server",
        produces => ["application/json"],
        responses => #{<<"200">> => #{description => <<"Succesful operation">>}
      }}

The json representation produces:

    "get":{"tags":["actions"],
           "responses":{"200":{"description":"Succesful operation"}},
           "produces":["application/json"],
           "parameters":"",
           "description":"Gets one or all actions from the server"}}}

Accorgind to Swagger 2.0 Spec the parameters should be a list not ""

This fixes the cowboy_swagger:normalize_map_values() function to takes
account empty lists.