### PR TITLE
Add missing jiffy app in .app.src

### DIFF
--- a/src/cowboy_swagger.app.src
+++ b/src/cowboy_swagger.app.src
@@ -6,7 +6,8 @@
   {applications,
    [kernel,
     stdlib,
-    trails
+    trails,
+    jiffy
    ]},
   {modules, []},
   {registered, []},


### PR DESCRIPTION
relx use this for building releases for instance