### PR TITLE
fixed dialyser error 'no local return' then definition includes an array

### DIFF
--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -32,10 +32,10 @@
 -type parameter_definition_name () :: binary().
 -type property_desc() ::
   #{ type => binary()
-  , description => binary()
-  , example => binary()
-  , items => property_desc()
-  }.
+   , description => binary()
+   , example => binary()
+   , items => property_desc()
+   }.
 -type property_obj() :: #{binary() => property_desc()}.
 -type parameters_definitions() ::
   #{parameter_definition_name() =>

--- a/src/cowboy_swagger.erl
+++ b/src/cowboy_swagger.erl
@@ -30,12 +30,13 @@
 -export_type([response_obj/0, responses_definitions/0]).
 
 -type parameter_definition_name () :: binary().
--type property_obj() ::
-  #{binary() =>
-      #{ type => binary()
-       , description => binary()
-       , example => binary()
-       }}.
+-type property_desc() ::
+  #{ type => binary()
+  , description => binary()
+  , example => binary()
+  , items => property_desc()
+  }.
+-type property_obj() :: #{binary() => property_desc()}.
 -type parameters_definitions() ::
   #{parameter_definition_name() =>
       #{ type => binary()


### PR DESCRIPTION
For the following example dialyzer will currently return the error "no local return" but generate a correct swagger.json file
```
Properties =
  #{<<"name">> =>
      #{ type => <<"string">>
      ,  description => <<"description">>
      }
  , <<"list">> =>
    #{type => <<"array">>
    , items => #{ type => <<"integer">> }
    }
  },
  ok = cowboy_swagger:add_definition(<<"PropertieName">>, Properties).
```
this pull request fixes the spec so dialyzer is happy